### PR TITLE
#22 Create the CLI

### DIFF
--- a/project/Commands.py
+++ b/project/Commands.py
@@ -1,0 +1,3 @@
+def quit(args):
+    print(args)
+    exit(0)

--- a/project/main.py
+++ b/project/main.py
@@ -1,0 +1,12 @@
+import Commands
+
+commands = {"quit": Commands.quit}
+
+if __name__ == "__main__":
+    while True:
+        inp = input("> ")
+        split = inp.split(" ")
+        try:
+            commands[split[0].lower()](split)
+        except KeyError:
+            print("Invalid command")


### PR DESCRIPTION
quit doesn't need to print the args, it's just there as an example for other commands that actually use args