### PR TITLE
Convert to using properties in Team

### DIFF
--- a/project/CLI.py
+++ b/project/CLI.py
@@ -21,7 +21,7 @@ def need_self(func):
         try:
             if not args[0].current_user:
                 return sc.permission_denied
-            if not args[0].current_user.is_admin() and not args[0].current_user.get_username() == args[1][1]:
+            if not args[0].current_user.is_admin() and not args[0].current_user.username == args[1][1]:
                 return sc.permission_denied
         except IndexError:
             return sc.invalid_param
@@ -240,10 +240,9 @@ def quit_question(self, args):
     if args[1] in self.game.teams:
         now = datetime.timedelta(days=datetime.datetime.now().day, hours=datetime.datetime.now().hour,
                                  minutes=datetime.datetime.now().minute, seconds=datetime.datetime.now().second)
-        if self.game.teams[args[1]].password == args[2]:
-            self.game.quit_question(now, args[1], args[2])
-            return "Question Quit, Your Next Question: \n" + self.game.landmarks[
-                self.game.teams[args[1]].current_landmark].question
+        if self.game.quit_question(now, args[1], args[2]):
+            return "Question Quit, Your Next Question: \n{}".format(
+                self.game.landmarks[self.game.teams[args[1]].current_landmark].question)
         return "Username and Password May Have Been Incorrect"
     return "Unrecognized Username"
 
@@ -699,8 +698,8 @@ class test_quit_question(unittest.TestCase):
 
     def test_quit(self):
         self.assertEqual(sc.login_success, self.cli.command("login Team1 1526"), "Login message not correct")
-        self.assertEqual(self.cli.command("giveup Team1 1526"), "Question Quit, Your Next Question: \n" + self.cli.game.landmarks[
-            self.cli.game.teams["Team1"].current_landmark].question,
+        self.assertEqual(self.cli.command("giveup Team1 1526"), "Question Quit, Your Next Question: \n{}".format(
+            self.cli.game.landmarks[self.cli.game.teams["Team1"].current_landmark].question),
                          "Could not quit question with proper login")
 
     def test_quit_bad_args(self):
@@ -740,9 +739,9 @@ class test_get_status(unittest.TestCase):
         tt = datetime.timedelta(days=0, hours=0, minutes=0, seconds=0)
         now = datetime.timedelta(days=datetime.datetime.now().day, hours=datetime.datetime.now().hour,
                                  minutes=datetime.datetime.now().minute, seconds=datetime.datetime.now().second)
-        for t in self.cli.game.teams["Team1"].timelog:
+        for t in self.cli.game.teams["Team1"].time_log:
             tt += t
-        currenttimecalc = (now - self.cli.game.teams["Team1"].clueTime)
+        currenttimecalc = (now - self.cli.game.teams["Team1"].clue_time)
         self.assertEqual(sc.login_success, self.cli.command("login Team1 1526"), "Login message not correct")
         stat_str = 'Points:{};You Are On Landmark:{};Current Landmark Elapsed Time:{};Time Taken For Landmarks:{}'
         self.assertEqual(
@@ -753,14 +752,14 @@ class test_get_status(unittest.TestCase):
         tt = datetime.timedelta(days=0, hours=0, minutes=0, seconds=0)
         now = datetime.timedelta(days=datetime.datetime.now().day, hours=datetime.datetime.now().hour,
                                  minutes=datetime.datetime.now().minute, seconds=datetime.datetime.now().second)
-        for t in self.cli.game.teams["Team1"].timelog:
+        for t in self.cli.game.teams["Team1"].time_log:
             tt += t
-        currenttimecalc = (now - self.cli.game.teams["Team1"].clueTime)
+        current_time_calc = (now - self.cli.game.teams["Team1"].clue_time)
         self.assertEqual(sc.login_success, self.cli.command("login gamemaker 1234"), "Login message not correct")
         stat_str = 'Points:{};You Are On Landmark:{};Current Landmark Elapsed Time:{};Time Taken For Landmarks:{}'
         self.assertEqual(
             stat_str.format(self.cli.game.teams["Team1"].points, self.cli.game.teams["Team1"].current_landmark,
-                            currenttimecalc, tt), self.cli.command("getstats Team1"), "Admin Couldn't user get stats")
+                            current_time_calc, tt), self.cli.command("getstats Team1"), "Admin Couldn't user get stats")
 
     def test_not_user(self):
         self.assertEqual(sc.login_success, self.cli.command("login Team2 1526"), "Login message not correct")

--- a/project/Landmark.py
+++ b/project/Landmark.py
@@ -7,30 +7,6 @@ class LandmarkI(ABC):
     def submit_answer(self, answer):
         pass
 
-    @abstractmethod
-    def get_question(self):
-        pass
-
-    @abstractmethod
-    def get_clue(self):
-        pass
-
-    @abstractmethod
-    def get_answer(self):
-        pass
-
-    @abstractmethod
-    def set_question(self):
-        pass
-
-    @abstractmethod
-    def set_clue(self):
-        pass
-
-    @abstractmethod
-    def set_answer(self):
-        pass
-
 
 class LandmarkFactory:
     def get_landmark(self, clue, question, answer):
@@ -41,28 +17,10 @@ class LandmarkFactory:
             self.question = question
             self.clue = clue
             self.answer = answer
-            self.pointValue = 100
+            self.point_value = 100
 
         def submit_answer(self, answer):
             pass
-
-        def get_clue(self):
-            return self.clue
-
-        def get_answer(self):
-            return self.answer
-
-        def get_question(self):
-            return self.question
-
-        def set_clue(self, clue):
-            self.clue = clue
-
-        def set_answer(self, answer):
-            self.answer = answer
-
-        def set_question(self, question):
-            self.question = question
 
         def __eq__(self, other):
             return self.clue == other.clue
@@ -76,42 +34,6 @@ class TestInit(unittest.TestCase):
         self.assertEqual("What does the plaque say?", self.landmark.clue, "Failed to set clue properly")
         self.assertEqual("Give me your tired, your poor, your huddled masses yearing to breathe free",
                          self.landmark.answer, "Failed to answer properly")
-
-
-class TestGetters(unittest.TestCase):
-    def setUp(self):
-        self.landmark = LandmarkFactory().get_landmark("What does the plaque say?",
-                                                       "Gift given by the French in New York?",
-                                                       "Give me your tired, your poor, your huddled masses yearing to breathe free")
-
-    def test_get_question(self):
-        self.assertEqual(self.landmark.question, self.landmark.get_question(), "Wrong question returned")
-
-    def test_get_clue(self):
-        self.assertEqual(self.landmark.clue, self.landmark.get_clue(), "Wrong clue returned")
-
-    def test_get_answer(self):
-        self.assertEqual(self.landmark.answer, self.landmark.get_answer(), "Wrong answer returned")
-
-
-class TestSetters(unittest.TestCase):
-    def setUp(self):
-        self.landmark = LandmarkFactory().get_landmark("What does the plaque say?",
-                                                       "Gift given by the French in New York?",
-                                                       "Give me your tired, your poor, your huddled masses yearing to breathe free")
-
-    def test_set_question(self):
-        self.landmark.set_question("blah?")
-        self.assertEqual("blah?", self.landmark.question, "question set improperly")
-
-    def test_set_clue(self):
-        self.landmark.set_clue("blah?")
-        self.assertEqual("blah?", self.landmark.clue, "clue set improperly")
-
-    def test_set_answer(self):
-        self.landmark.set_answer("blah?")
-        self.assertEqual("blah?", self.landmark.answer, "answer set improperly")
-
 
 
 if __name__ == "__main__":

--- a/project/Team.py
+++ b/project/Team.py
@@ -1,5 +1,4 @@
 import unittest
-import datetime
 from abc import ABC, abstractmethod
 from GameMaker import UserABC
 
@@ -7,14 +6,6 @@ from GameMaker import UserABC
 class TeamI(ABC):
     @abstractmethod
     def login(self, username, password):
-        pass
-
-    @abstractmethod
-    def changeName(self, name):
-        pass
-
-    @abstractmethod
-    def changePassword(self, password):
         pass
 
     @abstractmethod
@@ -26,55 +17,49 @@ class TeamI(ABC):
         pass
 
     @abstractmethod
-    def get_username(self):
-        pass
-
-    @abstractmethod
-    def get_password(self):
-        pass
-
-    @abstractmethod
-    def get_points(self):
-        pass
-
-    @abstractmethod
-    def set_points(self, points):
-        pass
-
-    @abstractmethod
     def add_penalty(self, penalty):
         pass
 
+    @property
     @abstractmethod
-    def clear_penalty(self):
+    def points(self):
+        pass
+
+    @points.setter
+    @abstractmethod
+    def points(self, points):
+        pass
+
+    @property
+    @abstractmethod
+    def password(self):
+        pass
+
+    @password.setter
+    @abstractmethod
+    def password(self, password):
         pass
 
 
 class TeamFactory:
-    def getTeam(self, username, password):
+    def get_team(self, username, password):
         return self.Team(username, password)
 
     class Team(TeamI, UserABC):
         def __init__(self, username, password):
             self.username = username
-            self.password = password
-            self.points = 0
+            self.__password = password
+            self.__points = 0
             self.current_landmark = 0
             self.penalty_count = 0
-            self.timelog = []
-            self.clueTime = None
+            self.time_log = []
+            self.clue_time = None
 
         def __eq__(self, other):
             return self.username == other.username
 
-        def changeName(self, name):
-            self.username = name
-
-        def changePassword(self, password):
-            self.password = password
-
         def login(self, username, password):
-            if username != self.username or password != self.password:
+            if username != self.username or password != self.__password:
                 return None
             return self
 
@@ -84,92 +69,89 @@ class TeamFactory:
         def get_status(self):
             return ""
 
-        def get_username(self):
-            return self.username
+        @property
+        def points(self):
+            return self.__points
 
-        def get_password(self):
-            return self.password
-
-        def get_points(self):
-            return self.points
-
-        def set_points(self, points):
-            try:
-                self.points = max(0, int(points))
-                return True
-            except ValueError:
-                return False
+        @points.setter
+        def points(self, points):
+            self.__points = max(0, points)
 
         def add_penalty(self, penalty=1):
             try:
-                if int(penalty) <= 0:
+                if penalty <= 0:
                     return False
-                self.penalty_count += int(penalty)
+                self.penalty_count += penalty
                 return True
             except ValueError:
                 return False
-
-        def clear_penalty(self):
-            self.penalty_count = 0
 
         def is_admin(self):
             return False
 
+        @property
+        def password(self):
+            return None
 
-class TestGetters(unittest.TestCase):
-    def setUp(self):
-        self.username = "TeamA"
-        self.password = "2123"
-        self.team = TeamFactory().getTeam(self.username, self.password)
-
-    def test_get_username(self):
-        self.assertEqual(self.username, self.team.get_username(), "Returned username incorrect")
+        @password.setter
+        def password(self, password):
+            self.__password = password
 
 
 class TestInit(unittest.TestCase):
     def test_init(self):
-        self.team = TeamFactory().getTeam("TeamA", "2123")
-        self.assertEqual("TeamA", self.team.username, "username value improperly set")
-        self.assertEqual("2123", self.team.password, "password value improperly set")
+        # pylint: disable=protected-access,no-member
+        team = TeamFactory().get_team("TeamA", "2123")
+        self.assertEqual("TeamA", team.username, "username value improperly set")
+        self.assertEqual("2123", team._Team__password, "password value improperly set")
 
 
-class TestGetPoints(unittest.TestCase):
+class TestPassword(unittest.TestCase):
     def setUp(self):
-        self.team = TeamFactory().getTeam("Team 1", "1234")
+        self.team = TeamFactory().get_team("Team1", "1234")
+
+    def test_get_password(self):
+        self.assertIsNone(self.team.password, "Got some password")
+
+    def test_set_password(self):
+        # pylint: disable=protected-access,no-member
+        self.team.password = "2132"
+        self.assertEqual("2132", self.team._Team__password, "Password not set properly")
+
+
+class TestPoints(unittest.TestCase):
+    # pylint: disable=protected-access,invalid-name,attribute-defined-outside-init
+    def setUp(self):
+        self.team = TeamFactory().get_team("Team 1", "1234")
 
     def test_get_points(self):
-        self.team.points = 100
-        self.assertEqual(100, self.team.get_points(), "Points are not setting properly")
-
-
-class TestSetPoints(unittest.TestCase):
-    def setUp(self):
-        self.team = TeamFactory().getTeam("Team 1", "1234")
+        self.team._Team__points = 32
+        self.assertEqual(32, self.team.points, "Failed to read 32 points properly")
 
     def test_add_once_positive(self):
-        self.team.set_points(100)
-        self.assertEqual(100, self.team.points, "Failed to set 100 points properly")
+        self.team.points = 100
+        self.assertEqual(100, self.team._Team__points, "Failed to set 100 points properly")
 
     def test_add_cumulative_positive(self):
-        self.team.set_points(100)
-        self.assertEqual(100, self.team.points, "Failed to set 100 points properly")
-        self.team.set_points(15)
-        self.assertEqual(15, self.team.points, "Failed to set 15 points properly")
+        self.team.points = 100
+        self.assertEqual(100, self.team._Team__points, "Failed to set 100 points properly")
+        self.team.points = 15
+        self.assertEqual(15, self.team._Team__points, "Failed to set 15 points properly")
 
     def test_add_once_negative(self):
-        self.team.set_points(-15)
-        self.assertEqual(0, self.team.points, "Cannot drop below the 0 threshold")
+        self.team.points = -15
+        self.assertEqual(0, self.team._Team__points, "Cannot drop below the 0 threshold")
 
     def test_add_cumulative_posandneg(self):
-        self.team.set_points(100)
-        self.assertEqual(100, self.team.points, "Failed to set 100 points properly")
-        self.team.set_points(-15)
-        self.assertEqual(0, self.team.points, "Failed to set 15 points properly")
+        self.team.points = 100
+        self.assertEqual(100, self.team._Team__points, "Failed to set 100 points properly")
+        self.team.points = -15
+        self.assertEqual(0, self.team._Team__points, "Failed to set 15 points properly")
 
 
 class TestTeamLogin(unittest.TestCase):
     def setUp(self):
-        self.team = TeamFactory().getTeam("team1", "password123")
+        self.team = TeamFactory().get_team("team1", "password123")
 
     def test_team_login_success(self):
         user = self.team.login("team1", "password123")
@@ -182,22 +164,9 @@ class TestTeamLogin(unittest.TestCase):
         self.assertEqual(None, user, "Invalid user returned")
 
 
-class TestEditTeam(unittest.TestCase):
-    def setUp(self):
-        self.team = TeamFactory().getTeam("team2", "password123")
-
-    def test_change_name(self):
-        self.team.changeName("team zebra")
-        self.assertEqual(self.team.username, "team zebra", "username was not changed")
-
-    def test_change_password(self):
-        self.team.changePassword("random")
-        self.assertEqual(self.team.password, "random", "password was not changed")
-
-
 class TestAddCurrentPenalty(unittest.TestCase):
     def setUp(self):
-        self.team = TeamFactory().getTeam("Team2", "password123")
+        self.team = TeamFactory().get_team("Team2", "password123")
 
     def test_add_pos_points(self):
         self.assertTrue(self.team.add_penalty(1), "Incorrect Penalty Value")
@@ -205,31 +174,14 @@ class TestAddCurrentPenalty(unittest.TestCase):
     def test_add_neg_points(self):
         self.assertFalse(self.team.add_penalty(-1), "Penalty points are being given neg values")
 
-    def test_add_str_points(self):
-        self.assertFalse(self.team.add_penalty("ABC"), "Penalty is allowing string input")
-
-
-class TestClearTeamPenalty(unittest.TestCase):
-    def setUp(self):
-        self.team = TeamFactory().getTeam("Team2", "password123")
-
-    def test_set_to_zero(self):
-        self.team.penalty_count = 1
-        self.assertNotEqual(0, self.team.penalty_count)
-        self.team.clear_penalty()
-        self.assertEqual(0, self.team.penalty_count, "Penalty not resetting to 0")
-
 
 if __name__ == "__main__":
     SUITE = unittest.TestSuite()
     SUITE.addTest(unittest.makeSuite(TestInit))
-    SUITE.addTest(unittest.makeSuite(TestGetters))
     SUITE.addTest(unittest.makeSuite(TestTeamLogin))
-    SUITE.addTest(unittest.makeSuite(TestEditTeam))
-    SUITE.addTest(unittest.makeSuite(TestSetPoints))
-    SUITE.addTest(unittest.makeSuite(TestGetPoints))
+    SUITE.addTest(unittest.makeSuite(TestPoints))
     SUITE.addTest(unittest.makeSuite(TestAddCurrentPenalty))
-    SUITE.addTest(unittest.makeSuite(TestClearTeamPenalty))
+    SUITE.addTest(unittest.makeSuite(TestPassword))
     RUNNER = unittest.TextTestRunner()
     RES = RUNNER.run(SUITE)
     print(RES)


### PR DESCRIPTION
This gets rid of a lot of getters and setters. Every member variable should be accessible by object.variable. If anything needs to be checked before setting or getting then they should be converted to properties (see Team.password and Team.points).
For password we can no longer get the team password, it will always return None if you try. If you need to authenticate a Team you need to call the login method.