### PR TITLE
Get Stats fix, Begin Work on Quit Question (WIP)

### DIFF
--- a/project/eScavenge/CLI.py
+++ b/project/eScavenge/CLI.py
@@ -268,6 +268,11 @@ def quit_question(self, args):
         return permission_denied
     elif rtn == Errors.NO_GAME:
         return no_game_running
+    elif rtn == Errors.FINAL_ANSWER:
+        finstr = "Question quit! You have completed the hunt! Here are your final stats:\n{}"
+        return finstr.format(self.game.get_status(timezone.now(), self.current_user.username))
+    elif rtn == Errors.LANDMARK_INDEX:
+        return "There are no more questions!"
     return "Question Quit, Your Next Question: \n{}".format(self.game.get_team_landmark(self.current_user).question)
 
 

--- a/project/eScavenge/models.py
+++ b/project/eScavenge/models.py
@@ -171,6 +171,8 @@ class Game(models.Model):
             return Errors.NO_GAME
         if not team.login(team.username, password):
             return Errors.INVALID_LOGIN
+        if self.landmarks.all().count() <= team.current_landmark:
+            return Errors.LANDMARK_INDEX
         team.current_landmark += 1
         temp = None
         try:
@@ -186,6 +188,8 @@ class Game(models.Model):
         team.penalty_count = 0
         team.full_clean()
         team.save()
+        if self.landmarks.all().count() == team.current_landmark:
+            return Errors.FINAL_ANSWER
         return Errors.NO_ERROR
 
     def answer_question(self, now, team, answer):
@@ -243,9 +247,17 @@ class Game(models.Model):
                         'Current Landmark Elapsed Time:{}\n'
                         'Total Time Taken:{}')
             return stat_str.format(place, self.teams.all().count(), current_team.points,
+                        current_team.current_landmark, self.landmarks.all().count(),
+                        str(current_time_calc).split(".")[0],
+                        str(total_time + current_time_calc).split(".")[0])
+        if current_team.current_landmark > self.landmarks.all().count(): #When The game is done
+            stat_str = ('You are in place {} of {} teams\n'
+                        'Points:{}\n'
+                        'You are on Landmark:{} of {}\n'
+                        'Total Time Taken:{}')
+            return stat_str.format(place, self.teams.all().count(), current_team.points,
                                    current_team.current_landmark, self.landmarks.all().count(),
-                                   str(current_time_calc).split(".")[0],
-                                   str(total_time + current_time_calc).split(".")[0])
+                                   str(total_time).split(".")[0])
         return f'Final Points: {current_team.points}'
 
     def get_snapshot(self):

--- a/project/eScavenge/test_CLI.py
+++ b/project/eScavenge/test_CLI.py
@@ -469,7 +469,13 @@ class TestQuitQuestion(TestCase):
         self.assertEqual("Proper Format giveup <username> <password>", self.cli.command("giveup teamp", "Team1"),
                          "Not enough args did not show correct message")
 
-
+    #def test_quit_last(self):
+     #    self.cli.current_user = Team.objects.get(username="Team1")
+      #   self.cli.current_user.current_landmark = 2
+         
+       #  self.assertEqual("Qu",
+        #                 self.cli.command("giveup Team1 1526", "Team1"), "Could not quit question with proper login")
+        
 class TestGetStatus(TestCase):
     def setUp(self):
         self.cli = CLI(COMMANDS)

--- a/project/eScavenge/test_Game.py
+++ b/project/eScavenge/test_Game.py
@@ -580,6 +580,7 @@ class TestQuitAndStatsProper(TestCase):
         temp = self.game.teams.get(username='abc')
         temp.points = 20
         temp.clue_time = timezone.now()
+        temp.landmark_index = 2
         temp.save()
         temp = self.game.teams.get(username='ghi')
         temp.points = 30
@@ -616,8 +617,16 @@ class TestQuitAndStatsProper(TestCase):
                          datetime.timedelta(days=0, hours=0, minutes=0, seconds=0),
                          "Time Log did not Save The Correct Time")
         self.assertEqual(self.game.teams.get(username='abc').clue_time, now, "Clue Time Did Not Update!")
-
-
+    def test_quit_last_question(self):
+        temp = self.game.teams.get(username='abc')
+        temp.current_landmark = 2
+        self.assertEqual(Errors.FINAL_ANSWER,self.game.quit_question(timezone.now(),temp,"def"),"quit_question did not notice it was the final question")
+        self.assertEqual(temp.current_landmark,3,"Quit did not properly increase landmark")
+    def test_quit_question_no_more(self):
+        temp = self.game.teams.get(username='abc')
+        temp.current_landmark = 3
+        self.assertEqual(Errors.LANDMARK_INDEX,self.game.quit_question(timezone.now(),temp,"def"),"quit_question did not notice team has no more questions")
+        self.assertEqual(temp.current_landmark,3, "Quit incrimented landmark, even though there were none left")
 class TestGameSnapShot(TestCase):
     def setUp(self):
         self.game = TEST_FACTORY('test')


### PR DESCRIPTION
🕐 Get Stats No Longer has a "time slip" after final question is answered
🔚  Quit Question did not check if it was on the final question or if it was passing the final question, WIP

Still need:
- Test_get_stats_after_final_question in game (theoretically works, untested due to server issues but did not conflict with any tests)
- Test_quit_last_question in CLI (redacted so get_stats changes could be uploaded faster)
- Test_quit_question_no_more in CLI 
- For Quit Question Messages to work on final question and after final question (CLI.py file issue)

Issues:
-quit_question in game passes correct Error to CLI, CLI does not seem to do the right thing though,
this may be a DB related issue